### PR TITLE
🐛 don't die on c==-1 or bad date; isoformat dates; output valid json

### DIFF
--- a/moz-idb-edit
+++ b/moz-idb-edit
@@ -16,7 +16,6 @@ import os
 import sys
 import typing as ty
 
-import jmespath
 import mozidb
 
 __dir__ = pathlib.Path(__file__).parent
@@ -194,11 +193,11 @@ def _safe_repr(object, context, maxlevels, level, sort_dicts):
 	return rep, (rep and not rep.startswith('<')), False
 
 _builtin_scalars = frozenset({str, bytes, bytearray, int, float, complex,
-                              bool, type(None)})
+			      bool, type(None)})
 
 def _recursion(object):
 	return ("<Recursion on %s with id=%s>"
-	        % (type(object).__name__, id(object)))
+		% (type(object).__name__, id(object)))
 
 class _safe_key:
 	"""Helper function for key functions when sorting unorderable objects.
@@ -219,7 +218,7 @@ class _safe_key:
 			return self.obj < other.obj
 		except TypeError:
 			return ((str(type(self.obj)), id(self.obj)) < \
-			        (str(type(other.obj)), id(other.obj)))
+				(str(type(other.obj)), id(other.obj)))
 
 def _safe_tuple(t):
     "Helper function for comparing 2-tuples"
@@ -249,16 +248,18 @@ def main(argv=sys.argv[1:], program=sys.argv[0]):
 	parser = argparse.ArgumentParser(description=__doc__, prog=pathlib.Path(program).name)
 	parser.add_argument("-V", "--version", action="version", version="%(prog)s {0}".format(__version__))
 	parser.add_argument("-x", "--extension", action="store", metavar="EXT_ID",
-	                    help="Use database of the extension with the given Extension ID.")
+			    help="Use database of the extension with the given Extension ID.")
 	parser.add_argument("--dbpath", action="store", metavar="DB_PATH", type=pathlib.Path,
-	                    help="Use database file with the the given path.")
+			    help="Use database file with the the given path.")
 	parser.add_argument("--userctx", action="store",
-	                    help="Use given user context (“Firefox container”) "
-	                         "when determining the database path.")
+			    help="Use given user context (“Firefox container”) "
+				 "when determining the database path.")
 	parser.add_argument("-profile", "--profile", metavar="PROFILE", type=pathlib.Path,
-	                    help="Path to the Firefox/MozTK application profile directory.")
+			    help="Path to the Firefox/MozTK application profile directory.")
+	parser.add_argument("--json", action="store_true",
+			    help="output as json instead of pretty printing")
 	parser.add_argument("key_name", metavar="KEY", default="@", nargs="?",
-	                    help="JMESPath of the key to query.")
+			    help="JMESPath of the key to query.")
 	
 	args = parser.parse_args(argv)
 	
@@ -301,12 +302,18 @@ def main(argv=sys.argv[1:], program=sys.argv[0]):
 		db_path = args.profile / "storage" / "default" / origin_label
 		db_path = db_path / "idb" / "3647222921wleabcEoxlt-eengsairo.sqlite"
 	
-	print(f"Using database path: {db_path}")
+	print(f"Using database path: {db_path}", file=sys.stderr)
 	
 	with mozidb.IndexedDB(db_path) as conn:
-		pretty_printer = PrettyPrinter()
-		pretty_printer.pprint(jmespath.search(args.key_name, IDBObjectWrapper(conn)))
-	
+		out = IDBObjectWrapper(conn)
+		if args.json:
+			import json
+			print(json.dumps({repr(k): v for k,v in out.items()}))
+		else:
+			import jmespath
+			print(f"searching key: {args.key_name}", file=sys.stderr)
+			pretty_printer = PrettyPrinter()
+			pretty_printer.pprint(jmespath.search(args.key_name, out))
 	return 0
 
 

--- a/mozidb.py
+++ b/mozidb.py
@@ -14,6 +14,7 @@ import io
 import os
 import struct
 import sqlite3
+import sys
 import time
 import typing as ty
 
@@ -227,6 +228,10 @@ class KeyCodec:
 					index += 1
 			
 			if type != KeyType.BINARY:
+				# likely c == -1
+				if c < 0:
+					print(f"WARNING: unhandled non-binary decode value < 0: {c}",file=sys.stderr)
+					c = c * -1
 				result += c.to_bytes(4, "little")
 			else:
 				result.append(c & 0xFF)
@@ -288,6 +293,9 @@ class IndexedDB(sqlite3.Connection):
 		while result is not None:
 			# Validate data
 			key_name, data, file_ids = result
+			if file_ids is not None:
+				print("WARNING: skipping non-None file_id: %s"%file_ids, file=sys.stderr)
+				break
 			assert file_ids is None  #XXX: TODO
 			
 			# Parse data

--- a/mozserial.py
+++ b/mozserial.py
@@ -14,6 +14,7 @@ import enum
 import io
 import re
 import struct
+import sys
 import typing as ty
 
 
@@ -506,8 +507,13 @@ class Reader:
 		
 		elif tag == DataType.DATE_OBJECT:
 			# These timestamps are always UTC
-			return True, datetime.datetime.fromtimestamp(self.input.read_double(),
-			                                             datetime.timezone.utc)
+			datenum = self.input.read_double()
+			try:
+				dateval = datetime.datetime.fromtimestamp(datenum, datetime.timezone.utc)
+			except:
+				print(f"WARNING: bad timestamp {datenum}", file=sys.stderr)
+				dateval = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+			return True, dateval.isoformat()
 		
 		elif tag == DataType.REGEXP_OBJECT:
 			flags = RegExpFlag(data)

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,37 @@
+# mozilla indexeddb reader
+Firefox's indexeddb backend is a sqlite file with unique encoding implemented in [`dom/indexeddb/Key.cpp`](https://hg.mozilla.org/mozilla-central/file/895e12563245/dom/indexedDB/Key.cpp). More on
+https://stackoverflow.com/questions/54920939/parsing-fb-puritys-firefox-idb-indexed-database-api-object-data-blob-from-lin
+
+## Usage
+
+### Example 1: calibre
+Extracting and building book reading position URLs from [calibre](https://calibre-ebook.com/)'s indexeddb entries.
+The important notes from this example are the location of the database, here as `$IDB`, and the output formula: either `--json` flag or `jmespath` query.
+ 
+
+The line noise that makes [`jq`](https://stedolan.github.io/jq/) pipe is useful only in illustrating post-processing -- you can ignore it and still understand `moz-idb-edit`.
+
+#### json
+```bash
+IDB=$HOME/.mozilla/firefox/leerowtj.dev-edition-default/storage/default/http+++192.168.1.130+8081/idb/2796537424cearlbi.sqlite
+./moz-idb-edit --dbpath $IDB --json |
+  jq -r '.[]|values|["#book_id=\(.key[1])&bookpos=\(.last_read_position|.[]|values)&fmt=\(.key[2])&library_id=\(.key[0])&mode=read_book"]|@tsv'
+```
+outputs
+> #book_id=294&bookpos=epubcfi(/16/2/4/86/2/1:0)&fmt=EPUB&library_id=calibre&mode=read_book
+> #book_id=296&bookpos=epubcfi(/2/2/4/2@0:0)&fmt=EPUB&library_id=calibre&mode=read_book
+> #book_id=308&bookpos=epubcfi(/26/2/4/2/2[chapter006]/8/2/1:0)&fmt=EPUB&library_id=calibre&mode=read_book
+
+####  jmespath
+ * A [`jmespath`](https://jmespath.org/) query can be used instead of outputting the entire db as json. No arguments default to "everything" `@`, i.e. `./moz-idb-edit --dbpath $IDB '@'`. NB. the python pretty printer used for displaying this is not guarantied to be valid json.
+
+```bash
+./moz-idb-edit --dbpath $IDB '*.[key[1], last_read_position.[*][0][0], key[2], key[0]]' # | jq -r '.[]|@tsv'
+```
+
+outputs
+```
+[[294, "epubcfi(/16/2/4/86/2/1:0)", "EPUB", "calibre"],
+ [296, "epubcfi(/2/2/4/2@0:0)", "EPUB", "calibre"],
+ [308, "epubcfi(/26/2/4/2/2[chapter006]/8/2/1:0)", "EPUB", "calibre"]]
+```


### PR DESCRIPTION
Probably better than my patches but I'm not sure how as it only seems to fix one bug but works anyway.

(Following generated automatically from readme)

--json flag to attempt to put valid json on stdout as a result, the script can work without either jmespath or json (but not both)

print to stderr for warnings in notifications so we can pipe to jq ignore lines that are file ids (instead of crash with failed assert)

mozidb.py:_decode_string() doesn't handle c == -1. just skips the whole thing mozserial.py:start_read() previously failed on bad date
                          now just use start of unix epoch (timestamp=0)

editor ate some of the tabs. unnecessary diffs as a result